### PR TITLE
Trim string when load gamesave

### DIFF
--- a/src/app/options/options.component.ts
+++ b/src/app/options/options.component.ts
@@ -30,7 +30,7 @@ export class OptionsComponent implements OnInit {
   }
 
   import(event: Event) {
-    this.gameService.game.load(this.stringSave)
+    this.gameService.game.load(this.stringSave.trim())
   }
 
 }


### PR DESCRIPTION
This avoids line breaks or spaces causing silence to fail.