### PR TITLE
Fix `D` in `Utils.solveCubic`

### DIFF
--- a/src/app/model/utils.ts
+++ b/src/app/model/utils.ts
@@ -44,7 +44,7 @@ export class Utils {
     } else if (q.abs().lessThan(Number.EPSILON)) { // q = 0 -> t^3 + pt = 0 -> t(t^2+p)=0
       roots = [new Decimal(0)].concat(p.lessThan(0) ? [(p.times(-1)).sqrt(), (p.times(-1)).sqrt().times(-1)] : [])
     } else {
-      const D = q.pow(2).div(new Decimal(4).plus(p.pow(3).div(27)))
+      const D = q.pow(2).div(4).plus(p.pow(3).div(27))
       // console.log("D: " + D.toString())
 
       if (D.abs().lessThan(Number.EPSILON)) {       // D = 0 -> two roots


### PR DESCRIPTION
The `D` in `Utils.solveCubic` should be `q^2 / 4 + p^3 / 27`. The `solveCubic` in [ant-utils](https://github.com/scorzy/ant-utils/blob/2813b705c196dd31369896921d6abde97ef3c7a7/src/solve-equation.ts#L108) seems fixed this issue already.